### PR TITLE
fix(vimeo): use protocol independent player url

### DIFF
--- a/views/default/videolist/watch/vimeo.php
+++ b/views/default/videolist/watch/vimeo.php
@@ -1,4 +1,4 @@
 <?php
 
-$vars['src'] = "http://player.vimeo.com/video/" . $vars['entity']->video_id . "?byline=0";
+$vars['src'] = "//player.vimeo.com/video/" . $vars['entity']->video_id . "?byline=0";
 echo elgg_view('videolist/iframe', $vars);


### PR DESCRIPTION
Vimeo support both http and https players. With this change it works without mixed content warnings